### PR TITLE
queryload.ps1 added

### DIFF
--- a/queryload.ps1
+++ b/queryload.ps1
@@ -1,0 +1,48 @@
+
+#Powershell script to create load
+#Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
+
+$SqlConnection = New-Object System.Data.SqlClient.SqlConnection
+$SqlConnection.ConnectionString = 'Server=NYCV-SQL17;Database=AdventureWorks2017;trusted_connection=true'
+# Load Product data
+$ProdCmd = New-Object System.Data.SqlClient.SqlCommand
+$ProdCmd.CommandText = "SELECT ProductID FROM Production.Product"
+$ProdCmd.Connection = $SqlConnection
+$SqlAdapter = New-Object System.Data.SqlClient.SqlDataAdapter
+$SqlAdapter.SelectCommand = $ProdCmd
+$ProdDataSet = New-Object System.Data.DataSet
+$SqlAdapter.Fill($ProdDataSet)
+# Set up the procedure to be run
+$WhereCmd = New-Object System.Data.SqlClient.SqlCommand
+$WhereCmd.CommandText = "dbo.uspGetWhereUsedProductID @StartProductID = @ProductId, @CheckDate=NULL"
+$WhereCmd.Parameters.Add("@ProductID",[System.Data.SqlDbType]"Int")
+$WhereCmd.Connection = $SqlConnection
+# And another one
+$BomCmd = New-Object System.Data.SqlClient.SqlCommand
+$BomCmd.CommandText = "dbo.uspGetBillOfMaterials @StartProductID = @ProductId, @CheckDate=NULL"
+$BomCmd.Parameters.Add("@ProductID",[System.Data.SqlDbType]"Int")
+$BomCmd.Connection = $SqlConnection
+# Bad Query
+$BadQuerycmd = New-Object System.Data.SqlClient.SqlCommand
+$BadQuerycmd.CommandText = "dbo.uspProductSize"
+$BadQuerycmd.Connection = $SqlConnection
+while(1 -ne 0)
+    {
+    #$RefID = $row[0]
+    $SqlConnection.Open()
+    $BadQuerycmd.ExecuteNonQuery() | Out-Null
+    $SqlConnection.Close()
+        foreach($row in $ProdDataSet.Tables[0])
+            {
+            $SqlConnection.Open()
+            $ProductId = $row[0]
+            $BomCmd.Parameters["@ProductID"].Value = $ProductId
+            $BomCmd.ExecuteNonQuery() | Out-Null
+            $SqlConnection.Close()
+            $SqlConnection.Open()
+            $ProductId = $row[0]
+            $WhereCmd.Parameters["@ProductID"].Value = $ProductId
+            $WhereCmd.ExecuteNonQuery() | Out-Null
+            $SqlConnection.Close()
+            }
+    }


### PR DESCRIPTION
In the book, p287 there is a missing $ProductId = $row[0] that should be included around line 38.  
foreach($row in $ProdDataSet.Tables[0])
{
$SqlConnection.Open()
****[MISSING $ProductId = $row[0] ]***
$BomCmd.Parameters["@ProductID"].Value = $ProductId
$BomCmd.ExecuteNonQuery() | Out-Null
$SqlConnection.Close()
$SqlConnection.Open()
$ProductId = $row[0]
$WhereCmd.Parameters["@ProductID"].Value = $ProductId
$WhereCmd.ExecuteNonQuery() | Out-Null
$SqlConnection.Close()
}
I uploaded my version that seems to work for queryload.ps1.